### PR TITLE
Test v21: Fix temp directory permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
           sha="${GITHUB_SHA}"
           echo "Creating PR in configs repo to update hello-http to SHA: $sha"
           
-          # Clean up and clone fresh to avoid permission issues
-          rm -rf /tmp/configs || true
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/justinmoon/configs.git" /tmp/configs
-          cd /tmp/configs
+          # Use unique temp directory to avoid permission issues
+          temp_dir="/tmp/configs-$$-${RANDOM}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/justinmoon/configs.git" "$temp_dir"
+          cd "$temp_dir"
           
           # Configure git
           git config user.name 'hello-http-bot'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,21 +53,10 @@ jobs:
           sha="${GITHUB_SHA}"
           echo "Creating PR in configs repo to update hello-http to SHA: $sha"
           
-          # Configure git safe directory
-          git config --global --add safe.directory /tmp/configs
-          
-          # Clone or pull configs repo
-          if [ -d "/tmp/configs/.git" ]; then
-            echo "Configs repo exists, pulling latest..."
-            cd /tmp/configs
-            git fetch origin
-            git checkout master
-            git reset --hard origin/master
-          else
-            echo "Cloning configs repo..."
-            git clone "https://x-access-token:${GH_TOKEN}@github.com/justinmoon/configs.git" /tmp/configs
-            cd /tmp/configs
-          fi
+          # Clean up and clone fresh to avoid permission issues
+          rm -rf /tmp/configs || true
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/justinmoon/configs.git" /tmp/configs
+          cd /tmp/configs
           
           # Configure git
           git config user.name 'hello-http-bot'

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           from http.server import BaseHTTPRequestHandler, HTTPServer
           
           # CHANGE THIS TO TEST DEPLOYMENTS
-          MESSAGE = "v19 - Full automation pipeline working! 🎉🚀"
+          MESSAGE = "v21 - Fixed temp directory permissions! 🔧🚀"
           
           class H(BaseHTTPRequestHandler):
               def log_message(self, format, *args):


### PR DESCRIPTION
Fixes the GitOps pipeline by using unique temporary directories to avoid permission conflicts.

**Problem**: Previous runs left  with permission denied files, causing  to fail even with .

**Solution**: Use unique temp directory names with  pattern.

**Testing**: v21 message to verify end-to-end pipeline works with this fix.

Should complete full workflow:
1. PR CI ✓ Build and test
2. Auto-merge when CI passes
3. Push CI creates configs repo PR  
4. Configs PR auto-merges
5. GitOps deployment

Message: v21 - Fixed temp directory permissions! 🔧🚀